### PR TITLE
Chore: use shared workflow files (fix #15)

### DIFF
--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,0 +1,13 @@
+name: Add to main project
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+  workflow_dispatch:
+jobs:
+  add-to-project:
+    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master
+    secrets: inherit


### PR DESCRIPTION
Fixes #15

### Update
- Migrate workflows to use the shared, reusable versions from the organization (`cgkineo/.github`)
- Workflows can be manually triggered via the `workflow_dispatch` event

### Note
Shared release workflow added in #14

Posted via collaboration with Claude Code
